### PR TITLE
Update media query for cta-img-box background-position

### DIFF
--- a/css/queries.css
+++ b/css/queries.css
@@ -347,4 +347,8 @@ on font-size: 62.5% of the html element */
         grid-row: 1;
         background-position: 70% 60%;
     }
+
+    .cta-text-box {
+        padding: 3.2rem;
+    }
 }


### PR DESCRIPTION
Image in call to action form is now centered using background-position CSS property, for screens below 736px